### PR TITLE
SERVO-1_Set_target

### DIFF
--- a/examples/simple/index.js
+++ b/examples/simple/index.js
@@ -14,5 +14,7 @@ var maestro = require("../../index").Maestro();
 // NOTE: The Maestro's serial mode must be set to "USB Dual Port".
 maestro.connect('/dev/cu.usbmodem00115481');
 
+maestro.setTarget(0, 6000);
+
 // disconnect
 maestro.disconnect();

--- a/src/maestro_servo_controller.h
+++ b/src/maestro_servo_controller.h
@@ -8,6 +8,11 @@
 #include <unistd.h>
 #include <termios.h>
 
+#define SET_TARGET_COMMAND    0x84
+#define GET_POSITION_COMMAND  0x90
+#define SET_SPEED_COMMAND     0x87
+#define SET_ACCEL_COMMAND     0x89
+
 // Maestro
 class Maestro : public Nan::ObjectWrap {
  public:
@@ -23,11 +28,13 @@ class Maestro : public Nan::ObjectWrap {
   static void Connect(const Nan::FunctionCallbackInfo<v8::Value>& info);
   static void Disconnect(const Nan::FunctionCallbackInfo<v8::Value>& info);
 
-  bool maestro_write(int device, unsigned char command, unsigned char* data, int length);
-  bool maestro_read(int device, unsigned char* buf, int length);
+  static void SetTarget(const Nan::FunctionCallbackInfo<v8::Value>& info);
 
   int               _maestro_device;
   const char*       _maestro_path;
+  int               _maestro_target_min;
+  int               _maestro_target_max;
+  int               _maestro_target_center;
 };
 
 #endif


### PR DESCRIPTION
Adds `setTarget` method; with following attributes:
- **channel**: the servo to control
- **target**: the target position for the servo shaft; _in quarter-microseconds_

Adds target **min/max** values, _in quarter-microseconds_:
- **min**: 2000
- **max**: 10000
- to protect servos from over-reaching; _servo-dependent_

Adds command constants:
- SET_TARGET_COMMAND: **0x84**
- GET_POSITION_COMMAND: **0x90**
- SET_SPEED_COMMAND: **0x87**
- SET_ACCEL_COMMAND: **0x89**

Updates example

References: [Maestro User Manual](http://www.robotshop.com/media/files/pdf/rb-pol-101_pololu_micro_maestro_6-channel_usb_servo_controller__assembled__user_manual.pdf)
