### PR TITLE
SERVO-2 Set speed

### DIFF
--- a/examples/simple/index.js
+++ b/examples/simple/index.js
@@ -1,20 +1,46 @@
-// Maestro object
-var maestro = require("../../index").Maestro();
-
-/*
+var servo = require("../../index").Maestro();
+/* ---------------------------------------------------------------------------------
   The following script will connect to a Micro Maestro 6-Channel Servo Controller
+------------------------------------------------------------------------------------ */
 
-  - device path:
-      Mac: '/dev/cu.usbmodem00115481'
-      Ubuntu: '/dev/ttyAMA0'
-      Raspi: '/dev/ttyACM0'
-*/
+/* ---------------------------------------------------
+  connect(device_path)
+    - device_path: the path to the Maestro device
 
-// connect
-// NOTE: The Maestro's serial mode must be set to "USB Dual Port".
-maestro.connect('/dev/cu.usbmodem00115481');
+        Mac: '/dev/cu.usbmodem00115481'
+        Ubuntu: '/dev/ttyAMA0'
+        Raspi: '/dev/ttyACM0'
 
-maestro.setTarget(0, 6000);
+  NOTE: The Maestro's serial mode must be set to "USB Dual Port".
+------------------------------------------------------ */
+servo.connect('/dev/cu.usbmodem00115481');
 
-// disconnect
-maestro.disconnect();
+
+/* ---------------------------------------------------
+  setTarget(channel, target)
+    - channel: servo number
+    - speed: servo speed
+------------------------------------------------------ */
+servo.setSpeed(0, 25);
+
+
+/* ---------------------------------------------------
+  setTarget(channel, target)
+    - channel: servo number
+    - target: the target servo posistion in quarter-microseconds
+
+  servo protections:
+    - servo min: 2000 (500us)
+    - servo max: 10000 (2500us)
+
+  for reference:
+    - servo center: ~6000 (1500us)
+------------------------------------------------------ */
+servo.setTarget(0, 6000);
+
+
+/* ---------------------------------------------------
+  disconnect()
+    - close connection to Maestro device
+------------------------------------------------------ */
+servo.disconnect();

--- a/src/maestro_servo_controller.cc
+++ b/src/maestro_servo_controller.cc
@@ -27,7 +27,7 @@ void Maestro::Init(v8::Local<v8::Object> exports) {
   Nan::SetPrototypeMethod(tpl, "connect", Connect);
   Nan::SetPrototypeMethod(tpl, "disconnect", Disconnect);
   Nan::SetPrototypeMethod(tpl, "setTarget", SetTarget);
-
+  Nan::SetPrototypeMethod(tpl, "setSpeed", SetSpeed);
 
   constructor.Reset(tpl->GetFunction());
   exports->Set(Nan::New("Maestro").ToLocalChecked(), tpl->GetFunction());
@@ -54,18 +54,11 @@ void Maestro::Connect(const Nan::FunctionCallbackInfo<v8::Value>& info) {
   Maestro* maestro = ObjectWrap::Unwrap<Maestro>(info.Holder());
   v8::String::Utf8Value device_path(info[0]->ToString());
   maestro->_maestro_path = (const char*)(*device_path);
-  // control communication configuration
-  printf("\nMaestro Virtual COM port: %s", maestro->_maestro_path);
-    printf("\nConnecting to Maestro board...");
   maestro->_maestro_device = open(maestro->_maestro_path, O_RDWR | O_NOCTTY);
-  if (maestro->_maestro_device == -1)
-  {
-    printf("\nFailed to connect!");
-    perror(maestro->_maestro_path);
-    info.GetReturnValue().Set(false);
-    return;
+
+  if (maestro->_maestro_device == -1) {
+    return info.GetReturnValue().Set(false);
   }
-  printf("\nConnected!\n");
   struct termios options;
   tcgetattr(maestro->_maestro_device, &options);
   options.c_iflag &= ~(INLCR | IGNCR | ICRNL | IXON | IXOFF);
@@ -74,7 +67,7 @@ void Maestro::Connect(const Nan::FunctionCallbackInfo<v8::Value>& info) {
   tcflush(maestro->_maestro_device, TCIFLUSH);
   tcsetattr(maestro->_maestro_device, TCSANOW, &options);
 
-  info.GetReturnValue().Set(true);
+  return info.GetReturnValue().Set(true);
 }
 
 // Disconnect
@@ -95,6 +88,26 @@ void Maestro::SetTarget(const Nan::FunctionCallbackInfo<v8::Value>& info) {
     channel,                               // channel
     (unsigned char)(target & 0x7F),        // target low byte
     (unsigned char)(target >> 7 & 0x7F)    // target high byte
+  };
+
+  if (write(maestro->_maestro_device, packet, sizeof(packet)) == -1) {
+  	return info.GetReturnValue().Set(false);
+  }
+
+  return info.GetReturnValue().Set(true);
+}
+
+// SetSpeed
+void Maestro::SetSpeed(const Nan::FunctionCallbackInfo<v8::Value>& info) {
+  Maestro* maestro = ObjectWrap::Unwrap<Maestro>(info.Holder());
+  unsigned char channel = (unsigned char)(info[0]->NumberValue());
+  unsigned short speed = (unsigned short)(info[1]->NumberValue());
+
+  unsigned char packet[] = {
+    SET_SPEED_COMMAND,                    // command
+    channel,                              // channel
+    (unsigned char)(speed & 0x7F),        // target low byte
+    (unsigned char)(speed >> 7 & 0x7F)    // target high byte
   };
 
   if (write(maestro->_maestro_device, packet, sizeof(packet)) == -1) {

--- a/src/maestro_servo_controller.cc
+++ b/src/maestro_servo_controller.cc
@@ -106,8 +106,8 @@ void Maestro::SetSpeed(const Nan::FunctionCallbackInfo<v8::Value>& info) {
   unsigned char packet[] = {
     SET_SPEED_COMMAND,                    // command
     channel,                              // channel
-    (unsigned char)(speed & 0x7F),        // target low byte
-    (unsigned char)(speed >> 7 & 0x7F)    // target high byte
+    (unsigned char)(speed & 0x7F),        // speed low byte
+    (unsigned char)(speed >> 7 & 0x7F)    // speed high byte
   };
 
   if (write(maestro->_maestro_device, packet, sizeof(packet)) == -1) {

--- a/src/maestro_servo_controller.h
+++ b/src/maestro_servo_controller.h
@@ -29,12 +29,13 @@ class Maestro : public Nan::ObjectWrap {
   static void Disconnect(const Nan::FunctionCallbackInfo<v8::Value>& info);
 
   static void SetTarget(const Nan::FunctionCallbackInfo<v8::Value>& info);
+  static void SetSpeed(const Nan::FunctionCallbackInfo<v8::Value>& info);
 
-  int               _maestro_device;
-  const char*       _maestro_path;
-  int               _maestro_target_min;
-  int               _maestro_target_max;
-  int               _maestro_target_center;
+  const char* _maestro_path;
+  int _maestro_device;
+  int _maestro_target_min;
+  int _maestro_target_max;
+  int _maestro_target_center;
 };
 
 #endif


### PR DESCRIPTION
Adds `setSpeed` method; with the following attributes:
- **channel**: the servo number
- **speed**: the servo speed

Updates example

References: [Maestro User Manual](http://www.robotshop.com/media/files/pdf/rb-pol-101_pololu_micro_maestro_6-channel_usb_servo_controller__assembled__user_manual.pdf)
