### PR TITLE
SERVO-4 Get position

### DIFF
--- a/examples/simple/index.js
+++ b/examples/simple/index.js
@@ -48,6 +48,13 @@ servo.setTarget(0, 6000);
 
 
 /* ---------------------------------------------------
+  getPosition(channel)
+    - channel: servo number
+------------------------------------------------------ */
+console.log('Servo position:', servo.getPosition(0));
+
+
+/* ---------------------------------------------------
   disconnect()
     - close connection to Maestro device
 ------------------------------------------------------ */

--- a/src/maestro_servo_controller.cc
+++ b/src/maestro_servo_controller.cc
@@ -29,6 +29,7 @@ void Maestro::Init(v8::Local<v8::Object> exports) {
   Nan::SetPrototypeMethod(tpl, "setTarget", SetTarget);
   Nan::SetPrototypeMethod(tpl, "setSpeed", SetSpeed);
   Nan::SetPrototypeMethod(tpl, "setAccel", SetAccel);
+  Nan::SetPrototypeMethod(tpl, "getPosition", GetPosition);
 
   constructor.Reset(tpl->GetFunction());
   exports->Set(Nan::New("Maestro").ToLocalChecked(), tpl->GetFunction());
@@ -136,4 +137,27 @@ void Maestro::SetAccel(const Nan::FunctionCallbackInfo<v8::Value>& info) {
   }
 
   return info.GetReturnValue().Set(true);
+}
+
+// SetAccel
+void Maestro::GetPosition(const Nan::FunctionCallbackInfo<v8::Value>& info) {
+  Maestro* maestro = ObjectWrap::Unwrap<Maestro>(info.Holder());
+  unsigned char channel = (unsigned char)(info[0]->NumberValue());
+
+  unsigned char packet[] = {
+    GET_POSITION_COMMAND,      // command
+    channel                    // channel
+  };
+
+  if (write(maestro->_maestro_device, packet, sizeof(packet)) == -1) {
+    return info.GetReturnValue().Set(false);
+  }
+
+  unsigned char response[2];
+
+  if (read(maestro->_maestro_device, response, 2) != 2) {
+    return info.GetReturnValue().Set(false);
+  }
+
+  return info.GetReturnValue().Set(response[0] + 256*response[1]);
 }

--- a/src/maestro_servo_controller.h
+++ b/src/maestro_servo_controller.h
@@ -31,6 +31,7 @@ class Maestro : public Nan::ObjectWrap {
   static void SetTarget(const Nan::FunctionCallbackInfo<v8::Value>& info);
   static void SetSpeed(const Nan::FunctionCallbackInfo<v8::Value>& info);
   static void SetAccel(const Nan::FunctionCallbackInfo<v8::Value>& info);
+  static void GetPosition(const Nan::FunctionCallbackInfo<v8::Value>& info);
 
   const char* _maestro_path;
   int _maestro_device;


### PR DESCRIPTION
Adds `getPosition` method; with the following attributes:
- **channel**: the servo number

**Returns:** the position of the servo 

Updates example

References: [Maestro User Manual](http://www.robotshop.com/media/files/pdf/rb-pol-101_pololu_micro_maestro_6-channel_usb_servo_controller__assembled__user_manual.pdf)
